### PR TITLE
fix(ch08): pin httpx<0.28 to fix OpenAI client compatibility

### DIFF
--- a/chapters/ch08/importer/ingest_and_process.py
+++ b/chapters/ch08/importer/ingest_and_process.py
@@ -637,28 +637,16 @@ if __name__ == "__main__":
 
     kg = FullKG(argv=sys.argv[1:])
 
-    base_path = kg.source_dataset_path
-    if not base_path:
-        print("Source path directory is mandatory. Setting it to default.")
-        base_path = "../../../data/"
-    base_path = Path(base_path)
-
-    prompt_path = kg.source_dataset_path
-    if not prompt_path:
-        print("Prompt path directory is mandatory. Setting it to default.")
-        prompt_path = "../../../data/"
-    prompt_path = Path(prompt_path)
-
     kg.openai_key = os.environ.get("OPENAI_KEY")
     kg.openai_url = os.environ.get("OPENAI_BASE_URL")
     kg.openai_model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
 
     # set up a cache folder for LLM responses
-    kg.cache_folder = Path("../../../data/cache_llm")
+    kg.cache_folder = base_path / "cache_llm"
     kg.cache_folder.mkdir(exist_ok=True)
 
     # build a KG layer (normalise & resolve entities)
-    kg.build_kg(prompt_path)
+    kg.build_kg(base_path)
 
     # run graph algorithms
     kg.run_gds()

--- a/chapters/ch08/requirements.txt
+++ b/chapters/ch08/requirements.txt
@@ -1,4 +1,5 @@
 neo4j~=4.4
 openai~=1.12
+httpx<0.28
 
 


### PR DESCRIPTION
## Summary

- `openai==1.12` internally passes a `proxies` kwarg to `httpx`, which was removed in `httpx 0.28.0`, causing a `TypeError` on startup
- Pins `httpx<0.28` in `chapters/ch08/requirements.txt` to restore compatibility
- Removes a redundant re-definition of `base_path` / `prompt_path` in `__main__` — these were already set via `DiariesImporter` earlier in the block

## Reproduction

```
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
```

Triggered when running `make import` with `httpx>=0.28` installed.
